### PR TITLE
Add pkg version parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,8 @@ class nginx (
   $service_restart        = $nginx::params::nx_service_restart,
   $mail                   = $nginx::params::nx_mail,
   $server_tokens          = $nginx::params::nx_server_tokens,
-  $logdir                 = $nginx::params::nx_logdir
+  $logdir                 = $nginx::params::nx_logdir,
+  $pkg_version            = $nginx::params::nx_pkg_version
 ) inherits nginx::params {
 
   include stdlib

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@ class nginx (
   include stdlib
 
   class { 'nginx::package':
+    pkg_version => $pkg_version,
     notify => Class['nginx::service'],
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -13,13 +13,14 @@
 # Sample Usage:
 #
 # This class file is not called directly
-class nginx::package {
+class nginx::package ($pkg_version) {
   anchor { 'nginx::package::begin': }
   anchor { 'nginx::package::end': }
 
   case $::operatingsystem {
     centos,fedora,rhel,redhat,scientific: {
       class { 'nginx::package::redhat':
+        pkg_version => $pkg_version,
         require => Anchor['nginx::package::begin'],
         before  => Anchor['nginx::package::end'],
       }

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -14,7 +14,7 @@
 #
 # This class file is not called directly
 class nginx::package::redhat ($pkg_version) {
-  $redhat_packages = ['nginx', 'GeoIP', 'gd', 'libXpm', 'libxslt']
+  $redhat_extra_packages = ['GeoIP', 'gd', 'libXpm', 'libxslt']
 
   if downcase($::operatingsystem) == 'redhat' {
     $os_type = 'rhel'
@@ -35,8 +35,12 @@ class nginx::package::redhat ($pkg_version) {
     gpgcheck => '0',
   }
 
-  package { $redhat_packages:
+  package { 'nginx':
     ensure  => $pkg_version,
+    require => Yumrepo['nginx-release'],
+  }
+  package { $redhat_extra_packages:
+    ensure  => 'present',
     require => Yumrepo['nginx-release'],
   }
 }

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -13,7 +13,7 @@
 # Sample Usage:
 #
 # This class file is not called directly
-class nginx::package::redhat {
+class nginx::package::redhat ($pkg_version) {
   $redhat_packages = ['nginx', 'GeoIP', 'gd', 'libXpm', 'libxslt']
 
   if downcase($::operatingsystem) == 'redhat' {
@@ -36,7 +36,7 @@ class nginx::package::redhat {
   }
 
   package { $redhat_packages:
-    ensure  => present,
+    ensure  => $pkg_version,
     require => Yumrepo['nginx-release'],
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@
 #
 # This class file is not called directly
 class nginx::params {
+  $nx_pkg_version             = 'present'
   $nx_temp_dir                = '/tmp'
   $nx_run_dir                 = '/var/nginx'
 


### PR DESCRIPTION
Add pkg_version parameter to ngninx class to support specific nginx versions.  For instance, versions that exist in our internal repo.
