### PR TITLE
Add $nginx_version

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,7 +27,8 @@ class nginx::config(
   $proxy_http_version     = $nginx::params::nx_proxy_http_version,
   $types_hash_max_size    = $nginx::params::nx_types_hash_max_size,
   $types_hash_bucket_size = $nginx::params::nx_types_hash_bucket_size,
-  $logdir                 = $nginx::params::nx_logdir
+  $logdir                 = $nginx::params::nx_logdir,
+  $nginx_version          = $nginx::params::nx_nginx_version
 ) inherits nginx::params {
   File {
     owner => 'root',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,7 +27,7 @@ class nginx::config(
   $proxy_http_version     = $nginx::params::nx_proxy_http_version,
   $types_hash_max_size    = $nginx::params::nx_types_hash_max_size,
   $types_hash_bucket_size = $nginx::params::nx_types_hash_bucket_size,
-  $nx_logdir              = $nginx::params::nx_logdir
+  $logdir                 = $nginx::params::nx_logdir
 ) inherits nginx::params {
   File {
     owner => 'root',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,7 +26,8 @@ class nginx::config(
   $proxy_cache_inactive   = $nginx::params::nx_proxy_cache_inactive,
   $proxy_http_version     = $nginx::params::nx_proxy_http_version,
   $types_hash_max_size    = $nginx::params::nx_types_hash_max_size,
-  $types_hash_bucket_size = $nginx::params::nx_types_hash_bucket_size
+  $types_hash_bucket_size = $nginx::params::nx_types_hash_bucket_size,
+  $nx_logdir              = $nginx::params::nx_logdir
 ) inherits nginx::params {
   File {
     owner => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,9 +40,10 @@ class nginx (
   $proxy_cache_max_size   = $nginx::params::nx_proxy_cache_max_size,
   $proxy_cache_inactive   = $nginx::params::nx_proxy_cache_inactive,
   $configtest_enable      = $nginx::params::nx_configtest_enable,
-  $service_restart        = $nginx::params::nx_service_restrart,
+  $service_restart        = $nginx::params::nx_service_restart,
   $mail                   = $nginx::params::nx_mail,
-  $server_tokens          = $nginx::params::nx_server_tokens
+  $server_tokens          = $nginx::params::nx_server_tokens,
+  $nx_logdir              = $nginx::params::nx_logdir
 ) inherits nginx::params {
 
   include stdlib
@@ -62,6 +63,7 @@ class nginx (
     proxy_cache_max_size  => $proxy_cache_max_size,
     proxy_cache_inactive  => $proxy_cache_inactive,
     confd_purge           => $confd_purge,
+    nx_logdir             => $nx_logdir,
     require               => Class['nginx::package'],
     notify                => Class['nginx::service'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,7 @@ class nginx (
   $service_restart        = $nginx::params::nx_service_restart,
   $mail                   = $nginx::params::nx_mail,
   $server_tokens          = $nginx::params::nx_server_tokens,
-  $logdir              = $nginx::params::nx_logdir
+  $logdir                 = $nginx::params::nx_logdir
 ) inherits nginx::params {
 
   include stdlib

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,7 @@ class nginx (
   $service_restart        = $nginx::params::nx_service_restart,
   $mail                   = $nginx::params::nx_mail,
   $server_tokens          = $nginx::params::nx_server_tokens,
-  $nx_logdir              = $nginx::params::nx_logdir
+  $logdir              = $nginx::params::nx_logdir
 ) inherits nginx::params {
 
   include stdlib
@@ -63,7 +63,7 @@ class nginx (
     proxy_cache_max_size  => $proxy_cache_max_size,
     proxy_cache_inactive  => $proxy_cache_inactive,
     confd_purge           => $confd_purge,
-    nx_logdir             => $nx_logdir,
+    logdir                => $logdir,
     require               => Class['nginx::package'],
     notify                => Class['nginx::service'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,13 @@ class nginx (
     notify => Class['nginx::service'],
   }
 
+  if $pkg_version == 'present' {
+    $nginx_version = $nginx::params::nx_nginx_version
+  } else {
+    $split_ver = split($pkg_version, '-')
+    $nginx_version = "$split_ver[0]"
+  }
+
   class { 'nginx::config':
     worker_processes      => $worker_processes,
     worker_connections    => $worker_connections,
@@ -66,6 +73,7 @@ class nginx (
     proxy_cache_inactive  => $proxy_cache_inactive,
     confd_purge           => $confd_purge,
     logdir                => $logdir,
+    nginx_version         => $nginx_version,
     require               => Class['nginx::package'],
     notify                => Class['nginx::service'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,8 +50,15 @@ class nginx (
   include stdlib
 
   class { 'nginx::package':
-    pkg_version => $pkg_version,
+    pkg_version => $pkg_version
     notify => Class['nginx::service'],
+  }
+  
+  if $pkg_version == 'present' {
+    $nginx_version = $nginx::params::nx_nginx_version
+  } else {
+    $split_ver = split($pkg_version, '-')
+    $nginx_version = "$split_ver[0]"
   }
 
   class { 'nginx::config':
@@ -66,6 +73,7 @@ class nginx (
     proxy_cache_inactive  => $proxy_cache_inactive,
     confd_purge           => $confd_purge,
     logdir                => $logdir,
+    pkg_version_family    => $pkg_version_family,
     require               => Class['nginx::package'],
     notify                => Class['nginx::service'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,8 @@ class nginx (
   $service_restart        = $nginx::params::nx_service_restart,
   $mail                   = $nginx::params::nx_mail,
   $server_tokens          = $nginx::params::nx_server_tokens,
-  $logdir                 = $nginx::params::nx_logdir
+  $logdir                 = $nginx::params::nx_logdir,
+  $pkg_version            = $nginx::params::nx_pkg_version
 ) inherits nginx::params {
 
   include stdlib

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@ class nginx (
   include stdlib
 
   class { 'nginx::package':
+    pkg_version => $pkg_version,
     notify => Class['nginx::service'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,13 +53,6 @@ class nginx (
     pkg_version => $pkg_version
     notify => Class['nginx::service'],
   }
-  
-  if $pkg_version == 'present' {
-    $nginx_version = $nginx::params::nx_nginx_version
-  } else {
-    $split_ver = split($pkg_version, '-')
-    $nginx_version = "$split_ver[0]"
-  }
 
   if $pkg_version == 'present' {
     $nginx_version = $nginx::params::nx_nginx_version

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class nginx (
   include stdlib
 
   class { 'nginx::package':
-    pkg_version => $pkg_version
+    pkg_version => $pkg_version,
     notify => Class['nginx::service'],
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -13,13 +13,14 @@
 # Sample Usage:
 #
 # This class file is not called directly
-class nginx::package {
+class nginx::package ($pkg_version) {
   anchor { 'nginx::package::begin': }
   anchor { 'nginx::package::end': }
 
   case $::operatingsystem {
     centos,fedora,rhel,redhat,scientific: {
       class { 'nginx::package::redhat':
+        pkg_version => $pkg_version,
         require => Anchor['nginx::package::begin'],
         before  => Anchor['nginx::package::end'],
       }

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -14,7 +14,7 @@
 #
 # This class file is not called directly
 class nginx::package::redhat ($pkg_version) {
-  $redhat_packages = ['nginx', 'GeoIP', 'gd', 'libXpm', 'libxslt']
+  $redhat_extra_packages = ['GeoIP', 'gd', 'libXpm', 'libxslt']
 
   if downcase($::operatingsystem) == 'redhat' {
     $os_type = 'rhel'
@@ -35,8 +35,12 @@ class nginx::package::redhat ($pkg_version) {
     gpgcheck => '0',
   }
 
-  package { $redhat_packages:
+  package { 'nginx':
     ensure  => $pkg_version,
+    require => Yumrepo['nginx-release'],
+  }
+  package { $redhat_extra_packages:
+    ensure  => 'present',
     require => Yumrepo['nginx-release'],
   }
 }

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -13,7 +13,7 @@
 # Sample Usage:
 #
 # This class file is not called directly
-class nginx::package::redhat {
+class nginx::package::redhat ($pkg_version) {
   $redhat_packages = ['nginx', 'GeoIP', 'gd', 'libXpm', 'libxslt']
 
   if downcase($::operatingsystem) == 'redhat' {
@@ -36,7 +36,7 @@ class nginx::package::redhat {
   }
 
   package { $redhat_packages:
-    ensure  => present,
+    ensure  => $pkg_version,
     require => Yumrepo['nginx-release'],
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,13 @@
 # This class file is not called directly
 class nginx::params {
   $nx_pkg_version             = 'present'
+  # If a pkg_version isn't specified we'll just assume a really high version
+  # so we don't have to keep adjusting this.  It's not ideal but there's no
+  # easy way to determine the pkg_version until after the package is
+  # installed. An alternative might be a resource that parses `nginx -V` and
+  # drops the version in a file and then grabbing that value but that's
+  # inelegant too.
+  $nx_nginx_version           = '9999'
   $nx_temp_dir                = '/tmp'
   $nx_run_dir                 = '/var/nginx'
 
@@ -77,5 +84,4 @@ class nginx::params {
   $nx_service_restart = '/etc/init.d/nginx configtest && /etc/init.d/nginx restart'
 
   $nx_mail = false
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@
 #
 # This class file is not called directly
 class nginx::params {
+  $nx_pkg_version             = 'present'
   $nx_temp_dir                = '/tmp'
   $nx_run_dir                 = '/var/nginx'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@
 # This class file is not called directly
 class nginx::params {
   $nx_pkg_version             = 'present'
+  $nx_nginx_version           = '1.0.0'
   $nx_temp_dir                = '/tmp'
   $nx_run_dir                 = '/var/nginx'
 
@@ -77,5 +78,4 @@ class nginx::params {
   $nx_service_restart = '/etc/init.d/nginx configtest && /etc/init.d/nginx restart'
 
   $nx_mail = false
-
 }

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -1,7 +1,7 @@
 user <%= scope.lookupvar('nginx::config::nx_daemon_user') %>;
 worker_processes <%= worker_processes %>;
 
-error_log  <%= scope.lookupvar('nginx::params::nx_logdir')%>/error.log;
+error_log  <%= scope.lookupvar('nginx::config::nx_logdir')%>/error.log;
 pid        <%= scope.lookupvar('nginx::params::nx_pid')%>;
 
 events {
@@ -14,7 +14,7 @@ http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
-  access_log  <%= scope.lookupvar('nginx::params::nx_logdir')%>/access.log;
+  access_log  <%= scope.lookupvar('nginx::config::nx_logdir')%>/access.log;
 
   sendfile    <%= scope.lookupvar('nginx::params::nx_sendfile')%>;
 

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -1,7 +1,7 @@
 user <%= scope.lookupvar('nginx::config::nx_daemon_user') %>;
 worker_processes <%= worker_processes %>;
 
-error_log  <%= scope.lookupvar('nginx::config::nx_logdir')%>/error.log;
+error_log  <%= nx_logdir %>/error.log;
 pid        <%= scope.lookupvar('nginx::params::nx_pid')%>;
 
 events {
@@ -14,7 +14,7 @@ http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
-  access_log  <%= scope.lookupvar('nginx::config::nx_logdir')%>/access.log;
+  access_log  <%= nx_logdir %>/access.log;
 
   sendfile    <%= scope.lookupvar('nginx::params::nx_sendfile')%>;
 

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -1,7 +1,7 @@
 user <%= scope.lookupvar('nginx::config::nx_daemon_user') %>;
 worker_processes <%= worker_processes %>;
 
-error_log  <%= nx_logdir %>/error.log;
+error_log  <%= logdir %>/error.log;
 pid        <%= scope.lookupvar('nginx::params::nx_pid')%>;
 
 events {
@@ -14,7 +14,7 @@ http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
-  access_log  <%= nx_logdir %>/access.log;
+  access_log  <%= logdir %>/access.log;
 
   sendfile    <%= scope.lookupvar('nginx::params::nx_sendfile')%>;
 

--- a/templates/conf.d/proxy.conf.erb
+++ b/templates/conf.d/proxy.conf.erb
@@ -5,6 +5,6 @@ proxy_connect_timeout   <%= scope.lookupvar('nginx::params::nx_proxy_connect_tim
 proxy_send_timeout      <%= scope.lookupvar('nginx::params::nx_proxy_send_timeout') %>;
 proxy_read_timeout      <%= scope.lookupvar('nginx::params::nx_proxy_read_timeout') %>;
 proxy_buffers           <%= scope.lookupvar('nginx::params::nx_proxy_buffers') %>;
-proxy_http_version      <%= @proxy_http_version %>;
+<% if @nginx_version >= '1.1.14' %>proxy_http_version      <%= @proxy_http_version %>;<% end %>
 <% proxy_set_header.each do |header| %>
 proxy_set_header        <%= header %>;<% end %>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -5,7 +5,7 @@ server {
   listen [<%= ipv6_listen_ip %>]:<%= ipv6_listen_port %> <% if @ipv6_listen_options %><%= ipv6_listen_options %><% end %> ipv6only=on;
   <% end %>
   server_name           <%= rewrite_www_to_non_www ? name.gsub(/^www\./, '') : server_name.join(" ") %>;
-  access_log            <%= scope.lookupvar('nginx::config::nx_logdir')%>/<%= name %>.access.log;
+  access_log            <%= scope.lookupvar('nginx::config::logdir')%>/<%= name %>.access.log;
   <% if defined? auth_basic -%>
 auth_basic           "<%= auth_basic %>";
   <% end -%>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -5,7 +5,7 @@ server {
   listen [<%= ipv6_listen_ip %>]:<%= ipv6_listen_port %> <% if @ipv6_listen_options %><%= ipv6_listen_options %><% end %> ipv6only=on;
   <% end %>
   server_name           <%= rewrite_www_to_non_www ? name.gsub(/^www\./, '') : server_name.join(" ") %>;
-  access_log            <%= scope.lookupvar('nginx::params::nx_logdir')%>/<%= name %>.access.log;
+  access_log            <%= scope.lookupvar('nginx::config::nx_logdir')%>/<%= name %>.access.log;
   <% if defined? auth_basic -%>
 auth_basic           "<%= auth_basic %>";
   <% end -%>


### PR DESCRIPTION
adds $nginx_version which is based off of $pkg_version.  If no $pkg_version is specified then we set it to a high value so checks against it (assuming we're looking for $pkg_version or later) pass.
