### PR TITLE
Fix $nginx_version.  Placing an array, even with a position, in quotes results in very unexpected behavior.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,7 @@ class nginx (
     $nginx_version = $nginx::params::nx_nginx_version
   } else {
     $split_ver = split($pkg_version, '-')
-    $nginx_version = "$split_ver[0]"
+    $nginx_version = $split_ver[0]
   }
 
   class { 'nginx::config':


### PR DESCRIPTION
a block in this manifest will figure out the nginx version based on the $pkg_version through splitting on the '-' in the $pkg_version.  Quoting alters the output.  ex.

"$split_ver[0]" = 1.0.153hs4[0]
$split_ver[0] = 1.0.15
