### PR TITLE
Add $http_additional_array parameter to nginx module.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,7 @@ class nginx::config(
   $worker_connections     = $nginx::params::nx_worker_connections,
   $worker_rlimit_nofile   = $nginx::params::nx_worker_rlimit_nofile,
   $events_use             = $nginx::params::nx_events_use,
+  $http_additional_array  = $nginx::params::nx_http_additional_array,
   $default_type           = $nginx::params::nx_default_type,
   $tcp_nopush             = $nginx::params::nx_tcp_nopush,
   $keepalive_timeout      = $nginx::params::nx_keepalive_timeout,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class nginx (
   $worker_connections     = $nginx::params::nx_worker_connections,
   $worker_rlimit_nofile   = $nginx::params::nx_worker_rlimit_nofile,
   $events_use             = $nginx::params::nx_events_use,
+  $http_additional_array  = $nginx::params::nx_http_additional_array,
   $default_type           = $nginx::params::nx_default_type,
   $tcp_nopush             = $nginx::params::nx_tcp_nopush,
   $keepalive_timeout      = $nginx::params::nx_keepalive_timeout,
@@ -66,7 +67,7 @@ class nginx (
   }
 
   # XXX: We should have a fact that gets the version number by running
-  # `nginx -V`.  If the package is not installed set to high number 
+  # `nginx -V`.  If the package is not installed set to high number
   # otherwise use value reported by binary.  If $pkg_version is set to
   # 'present' we'll just use the fact value to set $.pkg_version.
   if $pkg_version == 'present' {
@@ -81,6 +82,7 @@ class nginx (
     worker_connections    => $worker_connections,
     worker_rlimit_nofile  => $worker_rlimit_nofile,
     events_use            => $events_use,
+    http_additional_array => $http_additional_array,
     default_type          => $default_type,
     tcp_nopush            => $tcp_nopush,
     keepalive_timeout     => $keepalive_timeout,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,6 +34,7 @@ class nginx::params {
   $nx_types_hash_bucket_size  = 512
   $nx_multi_accept            = off
   $nx_events_use         = false # One of [kqueue|rtsig|epoll|/dev/poll|select|poll|eventport] or false to use OS default
+  $nx_http_additional_array   = undef
   $nx_default_type            = 'application/octet-stream'
   $nx_sendfile                = on
   $nx_keepalive_timeout       = 65

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -13,6 +13,11 @@ events {
 
 http {
   include       /etc/nginx/mime.types;
+  <% if @http_additional_array %>
+  <% @http_additional_array.each do |setting| -%>
+  <%= setting[0] %>   <%= setting[1] %>;
+  <% end -%>
+  <% end -%>
   default_type  <%= @default_type %>;
 
   access_log  <%= logdir %>/access.log;


### PR DESCRIPTION
The $http_additional_array parameter takes an array of key/value pairs for use in passing additional configuration to the http{} block of nginx.conf. The avoids the need to add a new parameter for every configuration directive required in our setup. Previously I was handling this by dropping a file into /etc/nginx/conf.d/ via hubspot::roles::nginx::role_elb. However an issue arose with access_log where a log_format was being specified before it was defined which was causing nginx to fail to start. Instead of adding a log_format parameter to the class I just added this parameter and killed of the file from hubspot::roles::nginx::role_elb.
