### PR TITLE
Fix proxy_http_version.

### DIFF
--- a/templates/conf.d/proxy.conf.erb
+++ b/templates/conf.d/proxy.conf.erb
@@ -5,7 +5,6 @@ proxy_connect_timeout   <%= @proxy_connect_timeout %>;
 proxy_send_timeout      <%= @proxy_send_timeout %>;
 proxy_read_timeout      <%= @proxy_read_timeout %>;
 proxy_buffers           <%= @proxy_buffers %>;
-proxy_http_version      <%= @proxy_http_version %>;
 <% if @nginx_version >= '1.1.14' %>proxy_http_version      <%= @proxy_http_version %>;<% end %>
 <% proxy_set_header.each do |header| %>
 proxy_set_header        <%= header %>;<% end %>


### PR DESCRIPTION
This happened as a result of a merge conflict introduced in commit 7d9c234e.  I've reviewed the PRs against hsmaster and do not see that commit in any of them.  The conflict was created while I was using a branch called new_parameters_merge where I merged all my separate feature branches into one in order to do some testing
with my test hosts.  That conflict then made its way into hsmaster.

ref.
https://github.com/hubspotdevops/puppet-nginx/commit/7d9c234e35c3eebddcad24f6d08f14926ed9ba63
