### PR TITLE
Add vhost log

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -92,6 +92,7 @@ define nginx::resource::vhost (
   $try_files              = undef,
   $auth_basic             = undef,
   $auth_basic_user_file   = undef,
+  $vhost_cfg_prepend      = undef,
   $vhost_cfg_append       = undef,
   $include_files		  = undef
 ) {

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -81,6 +81,8 @@ define nginx::resource::vhost (
     'index.html',
     'index.htm',
     'index.php'],
+  $logdir                 = $nginx::params::nx_logdir,
+  $access_log             = "${name}.${nginx::params::nx_logdir}",
   $server_name            = [$name],
   $www_root               = undef,
   $rewrite_www_to_non_www = false,

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -1,4 +1,8 @@
 server {
+<% if @vhost_cfg_prepend -%><% vhost_cfg_prepend.each do |key,value| -%>
+  <%= key %> <%= value %>;
+<% end -%><% end -%>
+
   listen                <%= listen_ip %>:<%= listen_port %> <% if @listen_options %><%= listen_options %><% end %>;
   <% # check to see if ipv6 support exists in the kernel before applying %>
   <% if ipv6_enable == 'true' && (defined? ipaddress6) %>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -5,7 +5,7 @@ server {
   listen [<%= ipv6_listen_ip %>]:<%= ipv6_listen_port %> <% if @ipv6_listen_options %><%= ipv6_listen_options %><% end %> ipv6only=on;
   <% end %>
   server_name           <%= rewrite_www_to_non_www ? name.gsub(/^www\./, '') : server_name.join(" ") %>;
-  access_log            <%= scope.lookupvar('nginx::config::logdir')%>/<%= name %>.access.log;
+  access_log            <%= @logdir %>/<%= @access_log %>;
   <% if defined? auth_basic -%>
 auth_basic           "<%= auth_basic %>";
   <% end -%>


### PR DESCRIPTION
Make logdir and access_log name configurable at vhost level.  Also add $vhost_cfg_prepend which we can use to define a log_format before we define access_log in the nginx.conf
