### PR TITLE
SSL config updates

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -70,8 +70,14 @@ define nginx::resource::vhost (
   $ipv6_listen_options    = 'default',
   $ssl                    = false,
   $ssl_cert               = undef,
+  $ssl_ciphers            = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4",
   $ssl_key                = undef,
   $ssl_port               = '443',
+  $ssl_protocols          = [
+    'TLSv1',
+    'TLSv1.1',
+    'TLSv1.2'
+  ],
   $proxy                  = undef,
   $proxy_read_timeout     = $nginx::params::nx_proxy_read_timeout,
   $proxy_set_header       = [],

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -16,7 +16,7 @@ server {
   ssl_session_cache         shared:SSL:10m;
   ssl_session_timeout       5m;
   ssl_ciphers               <%= @ssl_ciphers %>;
-  ssl_protocols             <%= @ssl_protocols.join(' ') %>;
+  ssl_protocols             <%= @ssl_protocols.join(' ')%>;
   ssl_prefer_server_ciphers on;
 
 <% if !@auth_basic.nil? -%>

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -15,8 +15,8 @@ server {
   ssl_certificate_key       <%= scope.lookupvar('nginx::params::nx_conf_dir') %>/<%= @name.gsub(' ', '_') %>.key;
   ssl_session_cache         shared:SSL:10m;
   ssl_session_timeout       5m;
-  ssl_ciphers               EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4;
-  ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers               <%= @ssl_ciphers %>;
+  ssl_protocols             <%= @ssl_protocols.join(' ') %>;
   ssl_prefer_server_ciphers on;
 
 <% if !@auth_basic.nil? -%>


### PR DESCRIPTION
# Description

Adds the option to specify TLS versions and cipher suites for vhosts. Will let us drop support for TLS versions <1.2 if we want 

Todo:
- [x] Test our modules that use this (in progress) 